### PR TITLE
Improve README and add start prompt to bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,55 @@
 # tg-graph
 
 Telegram chat interaction analyzer.
+
+## How to run the bot
+
+Follow these steps even if you have never written code before.
+
+1. **Install Python**. Visit [python.org](https://www.python.org/downloads/) and download
+   the latest Python 3 installer for your operating system. During installation
+   make sure that the option to add Python to your `PATH` is checked.
+
+2. **Get the project files**. Click the green “Code” button on the GitHub page
+   and choose “Download ZIP”. After downloading, unzip the archive to a folder on
+   your computer.
+
+3. **Install the required libraries**. Open a terminal (on Windows you can use
+   *Command Prompt*). Change to the folder with the unzipped files and run:
+
+   ```bash
+   pip install aiogram networkx matplotlib reportlab
+   ```
+
+4. **Create a Telegram bot**. In Telegram open `@BotFather`, send the command
+   `/newbot` and follow the instructions. BotFather will give you a token that
+   looks like a long string of letters and numbers. Keep this token handy.
+
+5. **Set the bot token**. In the terminal run the following command, replacing
+   `TOKEN` with the token you received from BotFather:
+
+   ```bash
+   export TG_BOT_TOKEN=TOKEN
+   ```
+
+   On Windows use `set` instead of `export`:
+
+   ```cmd
+   set TG_BOT_TOKEN=TOKEN
+   ```
+
+6. **Start the bot**. Still in the project folder, run:
+
+   ```bash
+   python -m tg_graph.bot
+   ```
+
+   You should see a message that the bot has started and is waiting for files.
+
+7. **Send a chat export**. Use Telegram’s built‑in export feature to save a chat
+   history as a JSON file (usually named `result.json`). Send this file to your
+   bot. After the upload finishes, the bot will analyze the chat and reply with a
+   PDF report containing statistics and a graph of interactions.
+
+That’s all! Every time you restart the bot you will need to set the
+`TG_BOT_TOKEN` environment variable again, so keep your token somewhere safe.

--- a/tg_graph/bot.py
+++ b/tg_graph/bot.py
@@ -12,6 +12,14 @@ bot = Bot(token=TOKEN)
 dp = Dispatcher(bot)
 
 
+@dp.message_handler(commands=['start'])
+async def start(message: types.Message):
+    await message.reply(
+        'Привет! Я могу проанализировать историю чата Telegram. '
+        'Пожалуйста, отправь мне файл экспорта чата (обычно это result.json).'
+    )
+
+
 @dp.message_handler(content_types=types.ContentType.DOCUMENT)
 async def handle_document(message: types.Message):
     file = await message.document.download(destination_dir='.')


### PR DESCRIPTION
## Summary
- guide non-developers on running the Telegram chat analysis bot
- prompt the user to send the chat export when the bot starts

## Testing
- `python -m tg_graph.bot` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_684b2f37c18483209b0b2490debf2458