### PR TITLE
Enhance output files and graph visualization

### DIFF
--- a/tg_graph/bot.py
+++ b/tg_graph/bot.py
@@ -34,8 +34,13 @@ async def handle_document(message: types.Message):
     metrics = compute_metrics(G)
     visualize_graph(G, metrics, 'graph.png')
     build_pdf('graph.png', metrics, 'report.pdf')
+    with open('graph.png', 'rb') as img:
+        await message.reply_document(img, caption='Граф взаимодействий')
     with open('report.pdf', 'rb') as doc:
-        await message.reply_document(doc, caption='Готово! Вот ваш отчёт.')
+        await message.reply_document(doc, caption='Подробный отчёт')
+    os.remove(file.name)
+    os.remove('graph.png')
+    os.remove('report.pdf')
 
 
 @dp.message_handler()

--- a/tg_graph/report.py
+++ b/tg_graph/report.py
@@ -1,4 +1,12 @@
-from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Image
+from reportlab.platypus import (
+    SimpleDocTemplate,
+    Paragraph,
+    Spacer,
+    Image,
+    Table,
+    TableStyle,
+)
+from reportlab.lib import colors
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.pagesizes import A4
 from typing import Dict
@@ -10,6 +18,23 @@ def build_pdf(graph_image: str, metrics: Dict[str, float], path: str) -> None:
     story = [Paragraph('Telegram Chat Report', styles['Title']), Spacer(1, 12)]
     story.append(Image(graph_image, width=400, height=300))
     story.append(Spacer(1, 12))
+
+    data = [['Metric', 'Value']]
     for key, value in metrics.items():
-        story.append(Paragraph(f'{key}: {value}', styles['Normal']))
+        data.append([key, value])
+
+    table = Table(data, hAlign='LEFT')
+    table.setStyle(
+        TableStyle([
+            ('BACKGROUND', (0, 0), (-1, 0), colors.grey),
+            ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+            ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+            ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+            ('GRID', (0, 0), (-1, -1), 0.5, colors.black),
+            ('ROWBACKGROUNDS', (0, 1), (-1, -1), [colors.beige, colors.lightblue]),
+        ])
+    )
+
+    story.append(table)
     doc.build(story)
+

--- a/tg_graph/visualization.py
+++ b/tg_graph/visualization.py
@@ -5,13 +5,30 @@ from typing import Dict
 
 def visualize_graph(G: nx.MultiDiGraph, metrics: Dict[str, float], path: str) -> None:
     plt.figure(figsize=(10, 8))
-    pos = nx.spring_layout(G)
-    weights = [data.get('weight', 1.0) for *_ , data in G.edges(data=True)]
-    nx.draw_networkx_nodes(G, pos, node_size=300)
-    nx.draw_networkx_edges(G, pos, width=weights, alpha=0.5, arrows=True)
+    # Spread nodes further apart for readability
+    pos = nx.spring_layout(G, k=1.2, seed=42)
+    weights = [data.get('weight', 1.0) for *_, data in G.edges(data=True)]
+
+    node_colors = range(G.number_of_nodes())
+    nx.draw_networkx_nodes(
+        G,
+        pos,
+        node_size=400,
+        node_color=node_colors,
+        cmap=plt.cm.Set3,
+        edgecolors="black",
+    )
+    nx.draw_networkx_edges(
+        G,
+        pos,
+        width=[w * 1.5 for w in weights],
+        alpha=0.7,
+        edge_color="gray",
+        arrows=True,
+    )
     nx.draw_networkx_labels(G, pos, font_size=8)
-    plt.axis('off')
-    plt.title('Telegram Chat Graph')
+    plt.axis("off")
+    plt.title("Telegram Chat Graph")
     plt.tight_layout()
     plt.savefig(path)
     plt.close()


### PR DESCRIPTION
## Summary
- improve graph layout and node styling
- format PDF metrics as colorful table
- send PNG graph and PDF report to users
- clean up files after sending

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b3f4982488320be524f9d5ca6881a