### PR TITLE
Improve visual output and stability

### DIFF
--- a/tg_graph/bot.py
+++ b/tg_graph/bot.py
@@ -1,9 +1,10 @@
 import os
+import gc
 from aiogram import Bot, Dispatcher, types
 from aiogram.utils import executor
-from .parser import load_chat, parse_messages
+from .parser import load_chat, parse_messages, parse_users
 from .graph_builder import compute_median_delta, build_graph
-from .metrics import compute_metrics
+from .metrics import compute_metrics, compute_interaction_strengths
 from .visualization import visualize_graph
 from .report import build_pdf
 
@@ -29,11 +30,17 @@ async def handle_document(message: types.Message):
     file = await message.document.download(destination_dir='.')
     data = load_chat(file.name)
     messages = parse_messages(data)
+    users = parse_users(data)
+    user_map = {u.id: (u.name or u.username or u.id) for u in users}
+    username_map = {u.username: (u.name or u.username) for u in users if u.username}
+    del data  # free memory early
+
     median = compute_median_delta(messages)
-    G = build_graph(messages, median)
+    G = build_graph(messages, median, user_map, username_map)
     metrics = compute_metrics(G)
+    strengths = compute_interaction_strengths(G)
     visualize_graph(G, metrics, 'graph.png')
-    build_pdf('graph.png', metrics, 'report.pdf')
+    build_pdf('graph.png', metrics, strengths, 'report.pdf')
     with open('graph.png', 'rb') as img:
         await message.reply_document(img, caption='Граф взаимодействий')
     with open('report.pdf', 'rb') as doc:
@@ -41,6 +48,8 @@ async def handle_document(message: types.Message):
     os.remove(file.name)
     os.remove('graph.png')
     os.remove('report.pdf')
+    del messages, users, metrics, strengths
+    gc.collect()
 
 
 @dp.message_handler()

--- a/tg_graph/metrics.py
+++ b/tg_graph/metrics.py
@@ -85,3 +85,12 @@ def compute_metrics(G: nx.MultiDiGraph) -> Dict[str, float]:
     except Exception:
         metrics['diameter'] = 0
     return metrics
+
+
+def compute_interaction_strengths(G: nx.MultiDiGraph) -> Dict[tuple, float]:
+    """Aggregate edge weights between every pair of participants."""
+    strengths: Dict[tuple, float] = {}
+    for u, v, data in G.edges(data=True):
+        key = (u, v)
+        strengths[key] = strengths.get(key, 0.0) + float(data.get("weight", 1.0))
+    return strengths

--- a/tg_graph/report.py
+++ b/tg_graph/report.py
@@ -9,7 +9,7 @@ from reportlab.platypus import (
 from reportlab.lib import colors
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.pagesizes import A4
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 
 def _format_metrics(metrics: Dict[str, float]) -> List[List[str]]:
@@ -47,11 +47,17 @@ def _format_metrics(metrics: Dict[str, float]) -> List[List[str]]:
     return rows
 
 
-def build_pdf(graph_image: str, metrics: Dict[str, float], path: str) -> None:
+def build_pdf(
+    graph_image: str,
+    metrics: Dict[str, float],
+    strengths: Dict[Tuple[str, str], float],
+    path: str,
+) -> None:
     doc = SimpleDocTemplate(path, pagesize=A4)
     styles = getSampleStyleSheet()
     story = [Paragraph("Telegram Chat Report", styles["Title"]), Spacer(1, 12)]
-    story.append(Image(graph_image, width=400, height=300))
+    # Slightly larger graph image for better readability in the PDF
+    story.append(Image(graph_image, width=500, height=380, kind="proportional"))
     story.append(Spacer(1, 12))
 
     data = _format_metrics(metrics)
@@ -71,5 +77,27 @@ def build_pdf(graph_image: str, metrics: Dict[str, float], path: str) -> None:
     )
 
     story.append(table)
+
+    # Connection strengths table
+    if strengths:
+        story.append(Spacer(1, 12))
+        story.append(Paragraph("Connection Strengths", styles["Heading2"]))
+        rows = [["From", "To", "Strength"]]
+        for (src, dst), val in sorted(strengths.items(), key=lambda x: x[1], reverse=True):
+            rows.append([src, dst, f"{val:.2f}"])
+        s_table = Table(rows, hAlign="LEFT", colWidths=[150, 150, 80])
+        s_table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.grey),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                    ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.black),
+                    ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.beige, colors.lightblue]),
+                ]
+            )
+        )
+        story.append(s_table)
     doc.build(story)
 

--- a/tg_graph/visualization.py
+++ b/tg_graph/visualization.py
@@ -2,6 +2,8 @@ import networkx as nx
 import matplotlib.pyplot as plt
 from typing import Dict
 
+plt.rcParams["font.family"] = "DejaVu Sans"
+
 
 def visualize_graph(G: nx.MultiDiGraph, metrics: Dict[str, float], path: str) -> None:
     """Save an interaction graph as a high resolution PNG image."""
@@ -11,13 +13,20 @@ def visualize_graph(G: nx.MultiDiGraph, metrics: Dict[str, float], path: str) ->
 
     # Spread nodes further apart so that labels do not overlap
     pos = nx.spring_layout(G, k=2.0, seed=42)
+    # Move the most connected nodes closer to the center
+    degrees = dict(G.degree())
+    if degrees:
+        top_nodes = sorted(degrees, key=degrees.get, reverse=True)[:3]
+        for n in top_nodes:
+            x, y = pos[n]
+            pos[n] = (x * 0.2, y * 0.2)
     weights = [float(data.get("weight", 1.0)) for *_, data in G.edges(data=True)]
 
     node_colors = range(G.number_of_nodes())
     nx.draw_networkx_nodes(
         G,
         pos,
-        node_size=600,
+        node_size=150,
         node_color=node_colors,
         cmap=plt.cm.tab20,
         edgecolors="black",
@@ -36,12 +45,12 @@ def visualize_graph(G: nx.MultiDiGraph, metrics: Dict[str, float], path: str) ->
     nx.draw_networkx_labels(
         G,
         pos,
-        font_size=10,
+        font_size=7,
         font_color="black",
         bbox=dict(facecolor="white", edgecolor="none", pad=0.2, alpha=0.8),
     )
 
     plt.axis("off")
     plt.tight_layout()
-    plt.savefig(path, format="png")
+    plt.savefig(path, format="png", bbox_inches="tight")
     plt.close()


### PR DESCRIPTION
## Summary
- set default font to DejaVu Sans for better glyph coverage
- shrink nodes and labels further
- robustly handle forwarded messages and reactions
- embed a larger graph in the PDF
- free memory after sending files

## Testing
- `python -m py_compile tg_graph/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684b444d9c7083208ca589281964adc0