### PR TITLE
Improve privacy in reports

### DIFF
--- a/tg_graph/graph_builder.py
+++ b/tg_graph/graph_builder.py
@@ -63,7 +63,7 @@ def build_graph(
                 fwd = str(fwd.get('id') or fwd.get('from_id') or fwd)
             else:
                 fwd = str(fwd)
-            target = user_map.get(fwd, username_map.get(fwd.lstrip('@'), fwd))
+            target = user_map.get(fwd) or username_map.get(fwd.lstrip('@')) or "Unknown"
             if target.lower() != "user":
                 G.add_edge(author, target, weight=INTERACTION_WEIGHTS['forward'])
         if m.reactions:
@@ -74,7 +74,7 @@ def build_graph(
                         actor = str(actor.get('id') or actor.get('from_id') or actor)
                     else:
                         actor = str(actor)
-                    actor_name = user_map.get(actor, username_map.get(actor.lstrip('@'), actor))
+                    actor_name = user_map.get(actor) or username_map.get(actor.lstrip('@')) or "Unknown"
                     if actor_name.lower() != "user":
                         G.add_edge(actor_name, author, weight=INTERACTION_WEIGHTS['reaction'])
         if last_message and median_delta > 0:


### PR DESCRIPTION
## Summary
- keep downloaded exports in `documents` folder
- strip any `from_id` info from outputs by using "Unknown" fallback
- ensure `documents` is emptied after sending reports

## Testing
- `python -m py_compile tg_graph/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684b4bab86588320a70c479b7fc4c796