### PR TITLE
Improve concurrency and sanitize Unicode

### DIFF
--- a/tg_graph/utils.py
+++ b/tg_graph/utils.py
@@ -2,8 +2,7 @@ import unicodedata
 
 
 def sanitize_text(text: str) -> str:
-    """Normalize fancy Unicode characters to improve font compatibility."""
+    """Normalize text and strip characters unsupported by common fonts."""
     normalized = unicodedata.normalize("NFKD", text)
-    return "".join(
-        ch for ch in normalized if unicodedata.category(ch)[0] != "S"
-    )
+    ascii_bytes = normalized.encode("ascii", "ignore")
+    return ascii_bytes.decode("ascii")


### PR DESCRIPTION
## Summary
- sanitize all labels to ASCII to avoid font warnings on Windows
- handle uploaded documents concurrently using temporary directories

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b5076769c832099c57de34fc41c98