### PR TITLE
Add interactive HTML output for graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Follow these steps even if you have never written code before.
 7. **Send a chat export**. Use Telegram’s built‑in export feature to save a chat
    history as a JSON file (usually named `result.json`). Send this file to your
    bot. After the upload finishes, the bot will analyze the chat and reply first
-   with a PNG image containing the interaction graph, followed by a PDF report
-   with a structured table of metrics.
+   with a PNG image containing the interaction graph, an HTML file with an
+   interactive version of the graph, and a PDF report with a structured table of
+   metrics.
 
 That’s all! Every time you restart the bot you will need to set the
 `TG_BOT_TOKEN` environment variable again, so keep your token somewhere safe.

--- a/tg_graph/bot.py
+++ b/tg_graph/bot.py
@@ -7,7 +7,7 @@ from aiogram.utils import executor
 from .parser import load_chat, parse_messages, parse_users
 from .graph_builder import compute_median_delta, build_graph
 from .metrics import compute_metrics, compute_interaction_strengths
-from .visualization import visualize_graph
+from .visualization import visualize_graph, visualize_graph_html
 from .report import build_pdf
 
 TOKEN = os.getenv('TG_BOT_TOKEN')
@@ -49,14 +49,18 @@ async def process_document(message: types.Message, file_path: str, workdir: str)
     strengths = compute_interaction_strengths(G)
 
     graph_path = os.path.join(workdir, 'graph.png')
+    html_path = os.path.join(workdir, 'graph.html')
     pdf_path = os.path.join(workdir, 'report.pdf')
     visualize_graph(G, metrics, graph_path)
+    visualize_graph_html(G, html_path)
     build_pdf(graph_path, metrics, strengths, pdf_path)
     with open(graph_path, 'rb') as img:
         await message.reply_document(img, caption='Граф взаимодействий')
+    with open(html_path, 'rb') as doc:
+        await message.reply_document(doc, caption='Интерактивный граф (HTML)')
     with open(pdf_path, 'rb') as doc:
         await message.reply_document(doc, caption='Подробный отчёт')
-    for fname in (file_path, graph_path, pdf_path):
+    for fname in (file_path, graph_path, html_path, pdf_path):
         try:
             os.remove(fname)
         except FileNotFoundError:


### PR DESCRIPTION
## Summary
- generate interactive HTML graph with hover info
- send generated HTML via Telegram bot
- document the HTML output in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684be032e6608320a30ebb315fffd0c9