### PR TITLE
Fix networkx label KeyError

### DIFF
--- a/tg_graph/visualization.py
+++ b/tg_graph/visualization.py
@@ -52,7 +52,8 @@ def visualize_graph(
     weights = [float(data.get("weight", 1.0)) for *_, data in agg.edges(data=True)]
 
     # Sanitize labels so exotic symbols do not break the font
-    labels = {node: sanitize_text(str(node)) for node in G.nodes()}
+    # Only include labels for nodes that will actually be drawn
+    labels = {node: sanitize_text(str(node)) for node in agg.nodes()}
     label_pos = _adjust_label_positions(pos)
 
     node_colors = range(agg.number_of_nodes())


### PR DESCRIPTION
## Summary
- sanitize labels for the nodes that are actually drawn

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684be9debc3c8320926f4b89a6b23c6a