### PR TITLE
Tune cluster forces and shrink legend

### DIFF
--- a/tg_graph/visualization.py
+++ b/tg_graph/visualization.py
@@ -37,12 +37,12 @@ def _cluster_layout(
     pos: Dict[str, tuple] = {}
     cluster_map: Dict[str, int] = {}
     angle_step = 2 * math.pi / len(communities)
-    # Increase radius between cluster centres so clusters are further apart
-    radius = 18.0
+    # Spread clusters further apart to reduce overlap
+    radius = 22.0
     for idx, community in enumerate(communities):
         sub = G.subgraph(community)
-        # Reduce k to pull nodes of the same cluster closer together
-        sub_pos = nx.spring_layout(sub, k=2.0, seed=42, weight=weight)
+        # Pull nodes of the same cluster closer together
+        sub_pos = nx.spring_layout(sub, k=1.0, seed=42, weight=weight)
         angle = angle_step * idx
         cx = radius * math.cos(angle)
         cy = radius * math.sin(angle)
@@ -299,7 +299,7 @@ def visualize_graph_html(
         "</defs>",
         "<g id='graph'></g>",
         "</svg>",
-        "<div id='legend' style='position:absolute;right:10px;top:10px;background:#fff;padding:6px;border:1px solid #ccc'>",
+        "<div id='legend' style='position:absolute;right:6px;top:6px;background:#fff;padding:4px;border:1px solid #ccc;font-size:11px'>",
         "<strong>Легенда</strong>",
         f"<div><svg width='40' height='6'><line x1='0' y1='3' x2='40' y2='3' stroke='{_edge_color(1)}' stroke-width='{_edge_width(1):.1f}'/></svg> Слабая связь</div>",
         f"<div><svg width='40' height='6'><line x1='0' y1='3' x2='40' y2='3' stroke='{_edge_color(3)}' stroke-width='{_edge_width(3):.1f}'/></svg> Средняя связь</div>",
@@ -314,7 +314,7 @@ def visualize_graph_html(
         "const g = d3.select('#graph');",
         "const clusters = Array.from(new Set(nodes.map(n => n.cluster)));",
         "const clusterCenters = {};",
-        "const radius = Math.min("+str(width)+", "+str(height)+") / 2;",
+        "const radius = Math.min("+str(width)+", "+str(height)+") / 1.8;",
         "clusters.forEach((c, i) => {",
         "    const angle = 2 * Math.PI * i / clusters.length;",
         "    clusterCenters[c] = {x: "+str(width/2)+" + radius * Math.cos(angle), y: "+str(height/2)+" + radius * Math.sin(angle)};",
@@ -336,10 +336,10 @@ def visualize_graph_html(
         "    .attr('text-anchor', 'middle').attr('alignment-baseline', 'middle');",
         "const simulation = d3.forceSimulation(nodes)",
         "    .force('link', d3.forceLink(links).id(d => d.id).distance(d => 150 / Math.max(d.weight, 0.1)).strength(d => Math.min(d.weight / 6, 1)))",
-        "    .force('charge', d3.forceManyBody().strength(-9000))",
+        "    .force('charge', d3.forceManyBody().strength(-14000))",
         "    .force('collide', d3.forceCollide().radius(d => d.radius + 8))",
-        "    .force('clusterX', d3.forceX(d => clusterCenters[d.cluster].x).strength(0.2))",
-        "    .force('clusterY', d3.forceY(d => clusterCenters[d.cluster].y).strength(0.2))",
+        "    .force('clusterX', d3.forceX(d => clusterCenters[d.cluster].x).strength(0.6))",
+        "    .force('clusterY', d3.forceY(d => clusterCenters[d.cluster].y).strength(0.6))",
         "    .force('center', d3.forceCenter("+str(width/2)+", "+str(height/2)+"));",
         "simulation.on('tick', () => {",
         "    link.attr('x1', d => d.source.x).attr('y1', d => d.source.y).attr('x2', d => d.target.x).attr('y2', d => d.target.y);",


### PR DESCRIPTION
## Summary
- tweak cluster layout to pull cluster nodes closer together and spread clusters apart
- bump D3 forces for stronger cluster attraction and repulsion
- reduce legend padding and font size so it covers less of the graph

## Testing
- `python -m py_compile tg_graph/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c13b60d248320bfd62c29c739fc36