### PR TITLE
Enable command-line bot launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,19 @@ Follow these steps even if you have never written code before.
    set TG_BOT_TOKEN=TOKEN
    ```
 
-6. **Start the bot**. Still in the project folder, run:
+6. **Start the bot**. You can run it directly from the command line. Still in
+   the project folder execute:
 
    ```bash
-   python -m tg_graph.bot
+   python -m tg_graph --token TOKEN
    ```
 
-   You should see a message that the bot has started and is waiting for files.
+   Replace `TOKEN` with the value you received from BotFather. Alternatively you
+   can set the `TG_BOT_TOKEN` environment variable instead of passing
+   ``--token``. After running the command you should see a message that the bot
+   has started and is waiting for files.
 
-   If you prefer not to use the command line, simply double-click
+   If you prefer not to use the command line, you can still double-click
    `launch_bot.py` in the project folder. A small window will appear where you
    can paste the bot token and press **"Запустить"**. The bot will start in the
    background and the window will remain open so you can close it to stop the

--- a/tg_graph/__main__.py
+++ b/tg_graph/__main__.py
@@ -1,0 +1,18 @@
+import argparse
+import os
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Run TG Graph bot')
+    parser.add_argument('--token', help='Telegram bot token')
+    args = parser.parse_args()
+
+    if args.token:
+        os.environ['TG_BOT_TOKEN'] = args.token
+
+    from .bot import main as bot_main
+    bot_main()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `tg_graph/__main__.py` to allow running the bot with `python -m tg_graph`
- update README with command-line launch instructions

## Testing
- `python -m tg_graph --help | head`
- `python -m tg_graph --token testtoken 2>&1 | head -n 20` *(fails: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_684c183b268483208ec7360f3d3dbabc