### PR TITLE
Handle large files and sanitize unsupported characters

### DIFF
--- a/tg_graph/utils.py
+++ b/tg_graph/utils.py
@@ -15,6 +15,12 @@ def sanitize_text(text: str) -> str:
         # typically present in the default Matplotlib font and cause warnings
         if cat.startswith("S"):
             continue
+        name = unicodedata.name(ch, "")
+        if any(
+            key in name
+            for key in ("CJK", "HIRAGANA", "KATAKANA", "HANGUL", "MONGOLIAN")
+        ):
+            continue
         # Escape the dollar sign to prevent Matplotlib from interpreting it as
         # a math text delimiter
         if ch == "$":


### PR DESCRIPTION
## Summary
- catch too-large export files in `bot.py`
- remove unsupported glyphs in `sanitize_text`

## Testing
- `python -m tg_graph --help`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ed43a53c083209015ed2633b50a13